### PR TITLE
Select active signature parameter by completion prefix

### DIFF
--- a/src/analysis/signature_help.mli
+++ b/src/analysis/signature_help.mli
@@ -1,10 +1,18 @@
+type parameter_info =
+  { label : Asttypes.arg_label
+  ; param_start : int
+  ; param_end : int
+  ; argument : Typedtree.expression option
+  }
+
 type application_signature =
   { fun_name : string option
   ; signature : string
-  ; param_offsets : (int * int) list
+  ; parameters : parameter_info list
   ; active_param : int option
   }
 
-val application_signature
-   : Mbrowse.t
+val application_signature :
+     prefix:string
+  -> Mbrowse.t
   -> [> `Application of application_signature | `Unknown ]


### PR DESCRIPTION
Uses a completion prefix to determine which labelled parameter is active. Previously, a labelled parameter would only be active if its full name was typed out.