### PR TITLE
Provide function position in application_signature

### DIFF
--- a/src/analysis/signature_help.ml
+++ b/src/analysis/signature_help.ml
@@ -12,7 +12,8 @@ type parameter_info =
   }
 
 type application_signature =
-  { fun_name : string option
+  { function_name : string option
+  ; function_position : Msource.position
   ; signature : string
   ; parameters : parameter_info list
   ; active_param : int option
@@ -96,7 +97,8 @@ let separate_function_signature ~args (e : Typedtree.expression) =
     | _ ->
       Format.fprintf ppf
         "%a%!" (pp_type e.exp_env) ty;
-      { fun_name = extract_ident e.exp_desc
+      { function_name = extract_ident e.exp_desc
+      ; function_position = `Offset e.exp_loc.loc_end.pos_cnum
       ; signature = Buffer.contents buffer
       ; parameters = List.rev parameters
       ; active_param = None

--- a/src/analysis/signature_help.mli
+++ b/src/analysis/signature_help.mli
@@ -6,7 +6,8 @@ type parameter_info =
   }
 
 type application_signature =
-  { fun_name : string option
+  { function_name : string option
+  ; function_position : Msource.position
   ; signature : string
   ; parameters : parameter_info list
   ; active_param : int option


### PR DESCRIPTION
Includes the position of the function being applied in the `application_signature` record so it can be used by the language server to provide function documentation information.