### PR TITLE
Use `/bin/sh` instead of `/bin/bash` to run system commands

### DIFF
--- a/src/ocaml/driver/pparse.ml
+++ b/src/ocaml/driver/pparse.ml
@@ -46,7 +46,7 @@ let merlin_system_command =
     windows_merlin_system_command
   else
     fun cmd ~cwd ->
-      let prog = "/bin/bash" in
+      let prog = "/bin/sh" in
       let argv = ["sh"; "-c"; cmd] in
       let stdin = Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0x777  in
       let pid =


### PR DESCRIPTION
Fixes https://github.com/ocaml/ocaml-lsp/issues/903

It's a draft for now, as I haven't tested this at all. I'll do that this weekend.