### PR TITLE
Update to latest merlin (4.7)

### DIFF
--- a/src/dot-protocol/merlin_dot_protocol.mli
+++ b/src/dot-protocol/merlin_dot_protocol.mli
@@ -90,3 +90,25 @@ type read_error =
 val read : in_channel:in_channel -> (directive list, read_error) Merlin_utils.Std.Result.t
 
 val write : out_channel:out_channel -> directive list -> unit
+
+module Make (IO : sig
+  type 'a t
+
+  module O : sig
+    val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
+  end
+end) (Chan : sig
+  type t
+
+  val read : t -> Csexp.t option IO.t
+
+  val write : t -> Csexp.t -> unit IO.t
+end) : sig
+  val read : Chan.t -> (directive list, read_error) Merlin_utils.Std.Result.t IO.t
+
+  module Commands : sig
+    val send_file : Chan.t -> string -> unit IO.t
+
+    val halt : Chan.t -> unit IO.t
+  end
+end

--- a/src/kernel/dune
+++ b/src/kernel/dune
@@ -14,7 +14,7 @@
   -open Merlin_specific
   -open Merlin_extend)
  (libraries merlin_config os_ipc ocaml_parsing ocaml_preprocess ocaml_typing ocaml_utils
-            merlin_extend merlin_specific merlin_utils merlin_dot_protocol))
+            merlin_extend merlin_specific merlin_utils merlin_dot_protocol spawn))
 
 (rule
   (targets standard_library.ml)

--- a/src/ocaml/driver/pparse.ml
+++ b/src/ocaml/driver/pparse.ml
@@ -46,7 +46,23 @@ let merlin_system_command =
     windows_merlin_system_command
   else
     fun cmd ~cwd ->
-      Sys.command (Printf.sprintf "cd %s && %s" (Filename.quote cwd) cmd)
+      let prog = "/bin/bash" in
+      let argv = ["sh"; "-c"; cmd] in
+      let stdin = Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0x777  in
+      let pid =
+        let cwd : Spawn.Working_dir.t = Path cwd in
+        let stdout = Unix.stderr in
+        Spawn.spawn ~cwd ~prog ~argv ~stdin ~stdout ()
+      in
+      let (_, status) = Unix.waitpid [] pid in
+      let res =
+        match (status : Unix.process_status) with
+        | WEXITED n -> n
+        | WSIGNALED _ -> -1
+        | WSTOPPED _ -> -1
+      in
+      Unix.close stdin;
+      res
 
 let ppx_commandline cmd fn_in fn_out =
   Printf.sprintf "%s %s %s%s"

--- a/src/ocaml/driver/pparse.ml
+++ b/src/ocaml/driver/pparse.ml
@@ -46,7 +46,7 @@ let merlin_system_command =
     windows_merlin_system_command
   else
     fun cmd ~cwd ->
-      let prog = "/bin/bash" in
+      let prog = "/bin/sh" in
       let argv = ["sh"; "-c"; cmd] in
       let stdin = Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0x777  in
       let pid =

--- a/src/ocaml/preprocess/dune
+++ b/src/ocaml/preprocess/dune
@@ -8,13 +8,13 @@
 
 (menhir
  (modules parser_raw)
- (enabled_if (<> %{profile} "release"))
+ (enabled_if false)
  (mode    promote)
  (flags :standard --inspection --table --cmly))
 
 (rule
   (targets parser_recover.ml)
-  (enabled_if (<> %{profile} "release"))
+  (enabled_if false)
   (deps    parser_raw.cmly)
   (mode    promote)
   (action
@@ -23,7 +23,7 @@
 
 (rule
   (targets parser_explain.ml)
-  (enabled_if (<> %{profile} "release"))
+  (enabled_if false)
   (deps    parser_raw.cmly)
   (mode    promote)
   (action
@@ -32,7 +32,7 @@
 
 (rule
   (targets parser_printer.ml)
-  (enabled_if (<> %{profile} "release"))
+  (enabled_if false)
   (deps    parser_raw.cmly)
   (mode    promote)
   (action


### PR DESCRIPTION
How the rebase was performed: 

1. drops https://github.com/rgrinberg/merlin/commit/1385c29fd9d0b825bee3778fa69866693098685b because it causes rebase conflict
2. rebases rgrinberg/merlin#master on ocaml/merlin#master
3. drops 9b0f538f47fbf1b7337f99842c31b5e060b38aaf because it's now implemented in ocaml-lsp
4. re-do https://github.com/rgrinberg/merlin/commit/1385c29fd9d0b825bee3778fa69866693098685b: change `src/ocaml/preprocess/dune` back as it was in https://github.com/rgrinberg/merlin/commit/1385c29fd9d0b825bee3778fa69866693098685b, build, and commit all changes